### PR TITLE
ci: run the pinned semantic-release instead of resolving latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: pnpm dlx semantic-release
+              run: pnpm exec semantic-release


### PR DESCRIPTION
The Release run for #53 failed at the `Release` step. `Lint` and `Test` — the gate added in that PR —
both passed; the failure is in the publish itself and predates both PRs.

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.11.1.
```

`pnpm dlx semantic-release` resolves and downloads the **latest** published semantic-release rather
than the `^23.1.1` already in `devDependencies` and in the lockfile. semantic-release has since
released a version requiring node `^22.14.0 || >=24.10.0`, while `.nvmrc` pins `v20.11.1`. The lane
would have broken on the next release regardless of what was being released — the last successful
run was 2025-09-03.

`pnpm exec` uses the version `run_install: true` already installed. That one declares
`"node": ">=20.8.1"` and runs on the pinned runtime. It also removes the wider problem: with `dlx`,
the release tool could change version between two runs with no change to this repository.

## Why not the alternatives

- **Bump `.nvmrc` to node 22 or 24.** Fixes this error, but changes the runtime for lint, test and
  build too, and leaves the release tool floating — the next major would break the lane again.
- **Pin the fetch (`pnpm dlx semantic-release@23`).** Works, but then the version is written in two
  places and they can drift.

Worth doing separately: `typedoc.yml` uses `npx typedoc` and has the same floating-version shape. It
is passing today, so it is not bundled here.

## Verification

Ran the pinned binary on node `v20.11.1` against `main` at `97d8f79`:

```
Found 4 commits since last release
Analysis of 4 commits complete: patch release
The next release version is 1.5.4
```

So merging this publishes **1.5.4**, carrying the finding-1 auth fix and the packaging changes from
#53. This PR's own commit is `ci:`, which has no release rule — the `fix:` commit already on `main`
is what produces the version, and it stays in range because 1.5.3 is still the last tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
